### PR TITLE
Add xhr support

### DIFF
--- a/elements/scene.js
+++ b/elements/scene.js
@@ -16,6 +16,9 @@ Vector = require("../lib/vector");
 
 Euler = require("../lib/euler");
 
+// jjg - xhr support
+XMLHttpRequest = require('xhr2');
+
 Scene = dom.HTMLElement;
 
 // fixme - these are added to all instances of htmlelement, not just the Scene
@@ -82,6 +85,7 @@ Scene.prototype.start = function(reflector){
         document: document,
         Vector: Vector,
         Euler: Euler,
+	XMLHttpRequest: XMLHttpRequest,
 
         channel : {
           log : function(message){

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "cors": "~2.5.2",
     "coffee-script": "~1.8.0",
     "glob": "~4.2.1",
-    "xmlbuilder": "~2.4.5"
+    "xmlbuilder": "~2.4.5",
+    "xhr2":"*"
   },
   "devDependencies": {
     "jasmine-node": "1.14.3"

--- a/scenes/thermometer.xml
+++ b/scenes/thermometer.xml
@@ -15,14 +15,12 @@
   <billboard position="-2 1 0" rotation="0 0.5 0">
     <![CDATA[
       <center style="color: #777; font-size: 30px; padding: 2px; margin: 0;">
-	The cubes color represents the current temperature of the laboratory. It spins each time a new reading is taken.
+		The cubes color represents the current temperature of the laboratory. It spins each time a new reading is taken.
       </center>
     ]]>
   </billboard>
 
 	<script>
-		// ui controls
-		//var temp_display = null; //document.getElementById('temp_display');
 		var temp_board = document.getElementById("tb");
 		
 		document.addEventListener("ready", function(event) {

--- a/scenes/thermometer.xml
+++ b/scenes/thermometer.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<scene>
+  <spawn position="0 0 5" />
+
+  <skybox style="color: linear-gradient(#fff, #abf)" />
+
+  <box scale="40 6 1" position="0 3 -20" style="color: white" />
+  <box scale="40 6 1" position="-20 3 0" rotation="0 1.57 0" style="color: white" />
+  <box scale="40 6 1" position="0 3 20" style="color: white" />
+  <box scale="40 6 1" position="20 3 0" rotation="0 1.57 0" style="color: white" />
+
+	<box id="tb" scale="1 1 1" position="-5 1 0" style="color: #000000"/>
+  <link href="/hello.xml" position="10 1 0" rotation="0 1.57 0" />
+
+  <billboard position="-2 1 0" rotation="0 0.5 0">
+    <![CDATA[
+      <center style="color: #777; font-size: 30px; padding: 2px; margin: 0;">
+	The cubes color represents the current temperature of the laboratory. It spins each time a new reading is taken.
+      </center>
+    ]]>
+  </billboard>
+
+	<script>
+		// ui controls
+		//var temp_display = null; //document.getElementById('temp_display');
+		var temp_board = document.getElementById("tb");
+		
+		document.addEventListener("ready", function(event) {
+			updateTemp();
+		});
+			
+		// update temp once a minute
+		setInterval(function(){
+			updateTemp();
+		}, 3000);
+		
+		function updateTemp(){
+		
+			temp_board.rotation.y += 2;
+				
+			var temp_req = new XMLHttpRequest();
+			var post_data = 'access_token=44306d872f533602c45b653ee360ab9a676fb411&params=A3';
+			temp_req.open('POST', 'https://api.spark.io/v1/devices/53ff69066667574837371267/analogread', true);
+			temp_req.setRequestHeader('Content-type','application/x-www-form-urlencoded');
+			temp_req.onreadystatechange = function(){
+				if(temp_req.readyState === 4 && temp_req.status === 200){
+						
+					var response = JSON.parse(temp_req.responseText);
+					var pin_value = parseInt(response.return_value);
+						
+					// convert ADC value to temp in F
+					voltage = pin_value * (3300 / 4096.0);
+					var temp_C = (voltage - 500) / 10;
+					var temp_F = (temp_C * 9.0 / 5.0) + 32;
+						
+					// update display
+					temp_board.style.color = rgbToHex(Math.round(temp_F),128,128);
+				}
+			}
+			
+			// send request
+			temp_req.send(post_data);
+			
+		}
+
+		function componentToHex(c) {
+		    var hex = c.toString(16);
+		    return hex.length == 1 ? "0" + hex : hex;
+		}
+		
+		function rgbToHex(r, g, b) {
+		    return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
+		}
+
+	</script>
+</scene>


### PR DESCRIPTION
I added xhr support so scenes can fetch external data using regular XMLHttpRequest().  I also included an example scene (temperature.xml) which demonstrates fetching a temperature value from a Spark microcontroller and rendering it as a color inside a scene.  I looked for a place to add this to the documentation but didn't have any luck, but if you point me in the right direction I'd be happy to write something up.